### PR TITLE
DDCYLS-7121: Fixing broken ecl account tests 

### DIFF
--- a/src/test/scala/uk/gov/hmrc/test/ui/pages/returns/ReturnsPage.scala
+++ b/src/test/scala/uk/gov/hmrc/test/ui/pages/returns/ReturnsPage.scala
@@ -30,7 +30,7 @@ object ReturnsPage extends BasePage {
   val url =
     s"${TestConfiguration.url("economic-crime-levy-returns-frontend")}/submit-economic-crime-levy-return/period/24XY"
 
-  val eclTaxYear: EclTaxYear   = EclTaxYear.fromDate(LocalDate.now().withYear(2026))
+  val eclTaxYear: EclTaxYear   = EclTaxYear.fromDate(LocalDate.now())
   val heading: String          =
     "Submit your Economic Crime Levy return for " + eclTaxYear.previous.startYear.toString + "-" + eclTaxYear.previous.finishYear.toString
   val recentDueHeading: String =


### PR DESCRIPTION
Fixing the account tests as noticed a hard coded year value which isnt needed now the tests were recently refactored so the dates werent static.